### PR TITLE
Creating info/oro.js and info/repo.js

### DIFF
--- a/commands/info/oro.js
+++ b/commands/info/oro.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const {MessageActionRow, MessageButton} = require('discord.js');
+module.exports = {
+    data: new SlashCommandBuilder()
+	.setName('oro')
+	.setDescription('Link to Orodruin\'s Gauss Shot Calculator'),
+    permissions: 0,
+    execute(interaction) {
+        const link = "https://docs.google.com/spreadsheets/d/1bviDWAJewa6KPyOfU7maWjnIsGxZjxeTmzPCPsQ1drs/"
+        const row = new MessageActionRow()
+                    .addComponents(
+                        new MessageButton()
+                        .setLabel("Visit Orodruin's Gauss Shot Calculator")
+                        .setStyle("LINK")
+                        .setURL(link)
+                    )
+        interaction.reply({ 
+            content: "📝 ".concat(link),
+            components: [row],
+        });
+    }
+};

--- a/commands/info/repo.js
+++ b/commands/info/repo.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const {MessageActionRow, MessageButton} = require('discord.js');
+module.exports = {
+    data: new SlashCommandBuilder()
+	.setName('repo')
+	.setDescription('Link to the Anti-Xeno Initiative\'s Ship Build Repository'),
+    permissions: 0,
+    execute(interaction) {
+        const link = "https://docs.google.com/spreadsheets/d/1tshjtvrFU9lDkd8kGcnsE1dRdGaDwqz-KKAr0RkDzWg/"
+        const row = new MessageActionRow()
+                    .addComponents(
+                        new MessageButton()
+                        .setLabel("Visit Anti-Xeno Initiative's Ship Build Repository")
+                        .setStyle("LINK")
+                        .setURL(link)
+                    )
+        interaction.reply({ 
+            content: "📝 ".concat(link),
+            components: [row],
+        });
+    }
+};


### PR DESCRIPTION
Added 2 commands to /info, linking Orodruin's calculator and AXI's official ship build repo. Feature requested by Mechan. 

Samples outputs: 
![image](https://user-images.githubusercontent.com/42897845/172476577-4837e3f1-be67-4cab-88c7-1c3632b6c6bc.png)
![image](https://user-images.githubusercontent.com/42897845/172476459-e98e7e87-1619-4128-92c4-2a32ac758e5a.png)
