### PR TITLE
Command creations and Maintenance

### DIFF
--- a/commands/admin/betrayal.js
+++ b/commands/admin/betrayal.js
@@ -2,7 +2,7 @@ const Discord = require("discord.js");
 const { SlashCommandBuilder } = require('@discordjs/builders');
 module.exports = {
     data: new SlashCommandBuilder()
-      .setName('mechan')
+      .setName('betrayal')
       .setDescription('Gives/Removes conspirator role')
     .addUserOption(option => option.setName('user')
         .setRequired(true)

--- a/commands/admin/mechan.js
+++ b/commands/admin/mechan.js
@@ -1,0 +1,27 @@
+const Discord = require("discord.js");
+const { SlashCommandBuilder } = require('@discordjs/builders');
+module.exports = {
+    data: new SlashCommandBuilder()
+      .setName('mechan')
+      .setDescription('Gives/Removes conspirator role')
+    .addUserOption(option => option.setName('user')
+        .setRequired(true)
+        .setDescription('Mention a user')),
+    permissions: 2,
+    execute(interaction) {
+        const conspirator_role_id = '800227831694229514' //axi conspirator roleID
+        let target = interaction.guild.members.cache.get(interaction.options.data.find(arg => arg.name === 'user').value)
+        let target_servername = target.nickname
+        cons_role = interaction.guild.roles.cache.find(role => role.id === conspirator_role_id)
+        if(target._roles.includes(conspirator_role_id))
+        {
+            target.roles.remove(cons_role)
+            interaction.reply({ content: `${target_servername} now does not have :poop: role.`})
+        }
+        else
+        {
+            target.roles.add(cons_role)
+            interaction.reply({ content: `${target_servername} has been granted the :poop: role.`})
+        }
+    }
+}

--- a/commands/fun/secretpro.js
+++ b/commands/fun/secretpro.js
@@ -1,0 +1,13 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+module.exports = 
+{
+    data: new SlashCommandBuilder()
+        .setName(`secretpro`)
+        .setDescription(`Hydra when's Secretpro`),
+    permissions: 0,
+    async execute(interaction) {
+        interaction.reply({
+            content: `:tharghydra: :question: <@319224862235164672>`
+        })
+    }
+}

--- a/commands/info/ranks.js
+++ b/commands/info/ranks.js
@@ -12,6 +12,7 @@ module.exports = {
 		const roleCache = message.guild.roles.cache
 		const row = new Discord.MessageActionRow()
         .addComponents(new Discord.MessageButton().setCustomId('challenge').setLabel('Challenge Ranks').setStyle('PRIMARY'),)
+		.addComponents(new Discord.MessageButton().setCustomId('competitive').setLabel('Competitive Ranks').setStyle('PRIMARY'),)
         .addComponents(new Discord.MessageButton().setCustomId('progression').setLabel('Progression Ranks').setStyle('PRIMARY'),)
         .addComponents(new Discord.MessageButton().setCustomId('other').setLabel('Other Ranks').setStyle('PRIMARY'),)
         message.reply({ content: "Select which ranks to list:", components: [row] });
@@ -28,16 +29,34 @@ module.exports = {
 						.setTitle("**Challenge Ranks**")
 						.setDescription(`Challenge Rank Statistics`)
 						.addFields(
+							{name: "Decent Pilot", value: roleCache.get("974673947784269824").members.size.toString(), inline: true},
+							{name: "The Swarm", value: roleCache.get("973093582481281044").members.size.toString(), inline: true},
+							{name: "Hephaestus Shunned", value: roleCache.get("963786177306054656").members.size.toString(), inline: true},
 							{name: "Cerberus' Bane", value: roleCache.get("913848672679247963").members.size.toString(), inline: true},
-							{name: "Caduceus' Glint", value: roleCache.get("810410422871785472").members.size.toString(), inline: true},
-							{name: "Ace", value: roleCache.get("650449319262158868").members.size.toString(), inline: true},
 							{name: "Astraea's Clarity", value: roleCache.get("868809340788834324").members.size.toString(), inline: true},
 							{name: "Snake Eater", value: roleCache.get("508638571565940736").members.size.toString(), inline: true},
 							{name: "Soaring Sleipnir", value: roleCache.get("603345251192537098").members.size.toString(), inline: true},
 							{name: "Annihilator", value: roleCache.get("528577192746287104").members.size.toString(), inline: true},
 							{name: "100% Club", value: roleCache.get("477645690630307841").members.size.toString(), inline: true},
 							{name: "Myrmidon", value: roleCache.get("810410728023916554").members.size.toString(), inline: true},
-							{name: "Vanguard", value: roleCache.get("642840616694317104").members.size.toString(), inline: true},
+							{name: "Vanguard", value: roleCache.get("642840616694317104").members.size.toString(), inline: true}
+						)
+					i.channel.send({ embeds: [returnEmbed.setTimestamp()] });
+				} catch (err) {
+					console.error(err);
+					i.channel.send({ content: `Something went wrong. Error: ${err}` });
+				}
+			}
+			if (i.customId === 'competitive') {
+				i.deferUpdate();
+				try {
+					const returnEmbed = new Discord.MessageEmbed()
+						.setColor('#FF7100')
+						.setTitle("**Competitive Ranks**")
+						.setDescription(`Competitive Rank Statistics`)
+						.addFields(
+							{name: "Caduceus' Glint", value: roleCache.get("810410422871785472").members.size.toString(), inline: true},
+							{name: "Ace", value: roleCache.get("650449319262158868").members.size.toString(), inline: true}
 						)
 					i.channel.send({ embeds: [returnEmbed.setTimestamp()] });
 				} catch (err) {
@@ -62,7 +81,7 @@ module.exports = {
 							{name: "Apollo's Wrath", value: roleCache.get("380254463170183180").members.size.toString(), inline: true},
 							{name: "Cyclopean Duo", value: roleCache.get("642848276135280668").members.size.toString(), inline: true},
 							{name: "Quadrivial Vestige", value: roleCache.get("406986080953434115").members.size.toString(), inline: true},
-							{name: "Recruit", value: roleCache.get("380247760668065802").members.size.toString(), inline: true},
+							{name: "Recruit", value: roleCache.get("380247760668065802").members.size.toString(), inline: true}
 						)
 					i.channel.send({ embeds: [returnEmbed.setTimestamp()] });
 				} catch (err) {
@@ -78,20 +97,25 @@ module.exports = {
 						.setTitle("**Other Ranks**")
 						.setDescription(`Other Rank Statistics`)
 						.addFields(
-							{name: "Carrier Commander", value: roleCache.get("720206853350359121").members.size.toString(), inline: true},
-							{name: "Collector", value: roleCache.get("476049331405717504").members.size.toString(), inline: true},
 							{name: "Exterminator", value: roleCache.get("528577143844634644").members.size.toString(), inline: true},
 							{name: "Defender", value: roleCache.get("528576199639957504").members.size.toString(), inline: true},
+							{name: "Mentor", value: roleCache.get("468153018899234816").members.size.toString(), inline: true},
+							{name: "Veteran", value: roleCache.get("811106163608780810").members.size.toString(), inline: true},
+							{name: "Collector", value: roleCache.get("476049331405717504").members.size.toString(), inline: true},
 							{name: "Party Champion", value: roleCache.get("638111509569863690").members.size.toString(), inline: true},
 							{name: "Party Survivor", value: roleCache.get("417401084198387713").members.size.toString(), inline: true},
-							{name: "Abyss Walker", value: roleCache.get("513828375706599428").members.size.toString(), inline: true},
-							{name: "Lernaean Seeker", value: roleCache.get("484470882325233684").members.size.toString(), inline: true},
-							{name: "Jaeger", value: roleCache.get("638143561698639872").members.size.toString(), inline: true},
-							{name: "Chasm Rover", value: roleCache.get("558374870208086017").members.size.toString(), inline: true},
-							{name: "Xeno Unraveler", value: roleCache.get("537743539862503425").members.size.toString(), inline: true},
-							{name: "Callous Fringe", value: roleCache.get("427826781752524800").members.size.toString(), inline: true},
-							{name: "Avower", value: roleCache.get("439500275280117760").members.size.toString(), inline: true},
 							{name: "Old Guard", value: roleCache.get("427304200737783810").members.size.toString(), inline: true},
+							{name: "Lernaean Seeker", value: roleCache.get("484470882325233684").members.size.toString(), inline: true},
+							{name: "Callous Fringe", value: roleCache.get("427826781752524800").members.size.toString(), inline: true},
+							{name: "Xeno Unraveler", value: roleCache.get("537743539862503425").members.size.toString(), inline: true},
+							{name: "Avower", value: roleCache.get("439500275280117760").members.size.toString(), inline: true},
+							{name: "BGS Loyalist", value: roleCache.get("712110659814293586").members.size.toString(), inline: true},
+							{name: "BGS Operator", value: roleCache.get("505888282484408340").members.size.toString(), inline: true},
+							{name: "Conspirator", value: roleCache.get("800227831694229514").members.size.toString(), inline: true},
+							{name: "Ambassador", value: roleCache.get("431671409375182849").members.size.toString(), inline: true},
+							{name: "Jaeger", value: roleCache.get("638143561698639872").members.size.toString(), inline: true},
+							{name: "Carrier Commander", value: roleCache.get("720206853350359121").members.size.toString(), inline: true},
+
 						)
 					i.channel.send({ embeds: [returnEmbed.setTimestamp()] });
 				} catch (err) {

--- a/commands/info/slf.js
+++ b/commands/info/slf.js
@@ -1,0 +1,27 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const Discord = require("discord.js");
+const config = require('../../config.json');
+module.exports = {
+    data: new SlashCommandBuilder()
+    .setName(`slf`)
+    .setDescription(`Posts the SLF Infographic`),
+    permissions: 0,
+    execute (interaction) {
+        const returnEmbed = new Discord.MessageEmbed()
+        .setTitle('Ship-Launched Fighters')
+        .setURL('https://www.antixenoinitiative.com/wiki/ship-builds/common-mistakes')
+        .setAuthor({name: 'Anti-Xeno Initiative',iconURL: config.icon})
+        .setThumbnail('https://cdn-longterm.mee6.xyz/plugins/commands/images/380246809076826112/1b407b966d73977b5d85d0ab03b3177486fed82614d84d11cc1d633fb19bf902.png')
+        .setDescription(`Unfortunately, all forms of Ship-Launched Fighter are effectively useless for AX combat. During an Interceptor fight, they will attract the swarm for a short period of time and will die to it in a matter of seconds at best. While the swarm is engaged with the SLF, it will fly much more erratically, making the destruction of the swarm a much more difficult task than without the presence of an SLF. This often results in a aggrivated swarm which can pose a huge issue to you.
+
+        The SLF will NOT attract the attention of the Interceptor, either. Fighter weapons do minimal damage, and NPC pilots will have low time on target making them only marginally useful for exerting. Furthermore, NPC SLF cannot specifically subtarget hearts, making them effectively useless for progressing the fight.
+        
+        In almost all cases a Fighter Bay is better off used for far more useful modules like Hull Reinforcements.
+        
+        _SIDE NOTE:_
+        - Fighter Pilots also steal half your combat EXP and a portion of your credits, even when not equipped.`)
+        .setFooter({ text: 'Ship-Launched Fighters', iconURL: config.icon });
+        interaction.reply({embeds: [returnEmbed]})
+        interaction.channel.send({content:`https://media.discordapp.net/attachments/625989888432537611/707451541405171733/SL-OOOF.gif`})
+    }
+}

--- a/commands/info/t10.js
+++ b/commands/info/t10.js
@@ -1,0 +1,27 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const Discord = require("discord.js");
+const config = require('../../config.json');
+module.exports = {
+    data: new SlashCommandBuilder()
+    .setName(`t10`)
+    .setDescription(`Posts the T10 Infographic`),
+    permissions: 0,
+    execute (interaction) {
+        const returnEmbed = new Discord.MessageEmbed()
+        .setTitle('Type-10 Defender')
+        .setAuthor({name: 'Anti-Xeno Initiative',iconURL: config.icon})
+        .setThumbnail('https://images-ext-2.discordapp.net/external/WoTs_UEfXkb6LQ6MdGXGznAPj5Fm12KsH6GmT4drd9I/https/cdn-longterm.mee6.xyz/plugins/commands/images/380246809076826112/50872c245865c41fd7045a2c26e57caba882e377df970b3991452da2ac7d2e1a.png')
+        .setDescription(`~~T10 is traaaaaaaaaaash~~
+        T10 is generally considered one of the worst possible ships for Anti-Xeno combat, especially versus Interceptors, despite what its description might imply. Reasons for this are numerous and will take quite long to explain in detail. If you have specific questions, our Mentors will be glad to answer them.
+        
+        Some other bad ships are....
+        - Anaconda (Too slow)
+        - Crusader (Downgraded Chieftain/Challenger)
+        - Mamba (Terrible convergence)
+        - Type-9 (Obviously)
+        
+        Ask a <@&468153018899234816> if you would like to know more about why these ships are so terrible for AX.`)
+        .setFooter({ text: 'Just dont do it....', iconURL: config.icon });
+        interaction.reply({embeds: [returnEmbed]})
+    }
+}


### PR DESCRIPTION
# Command creations:
>Remade the T10 embed and created an info command /t10, permission level 0
![image](https://user-images.githubusercontent.com/42897845/185793530-a942bc13-d7d9-4068-8d91-d919bfd3dfd0.png)
>>Quick Note: deleted-role is mentor, just doesn't show up in test server.


>Remade SLF embed, also exists in info commands, permission level 0
![image](https://user-images.githubusercontent.com/42897845/185799719-d8988e98-6764-443e-85f5-d0fce3eb0df1.png)

>Created /mechan with permission level 2 to **grant/remove conspirator role** to a selected user. (command name change may be required)
![image](https://user-images.githubusercontent.com/42897845/185793594-0c1ad9ac-fde5-42bf-ae4b-b3afcf7662bc.png)
![image](https://user-images.githubusercontent.com/42897845/185793600-c19b26f1-be58-40a8-9162-0f72e304e9c8.png)
>> **UPDATE**: command renamed to "bertrayal"

# Ranks.js updates:
>Removed Chasm Rover and Abyss Walker. This was most likely causing errors when choosing "Other Ranks" and subsequently crashing warden.
![image](https://user-images.githubusercontent.com/42897845/185793750-ac67ee7e-5d83-4c5b-a47d-cb29b0c8a21c.png)

>Added new challenge ranks
>Added challenge ranks option to be consistent with rank types as listed in AXI's rank page
![image](https://user-images.githubusercontent.com/42897845/185793633-2e05ca51-3934-45ef-8019-f9e7afe360bd.png)

# Fun commands added:
> Added secretpro.js to hydra when and ping secret pro, on request by mechan.
