### PR TITLE
colorConvert issue fixed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1362,7 +1362,7 @@
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/undici": {
-     "version": "5.21.2",
+      "version": "5.21.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.21.2.tgz",
       "integrity": "sha512-f6pTQ9RF4DQtwoWSaC42P/NKlUjvezVvd9r155ohqkwFNRyBKM3f3pcty3ouusefNRyM25XhIQEbeQ46sZDJfQ==",
       "dependencies": {


### PR DESCRIPTION
Made the new discord.js version accept the color formatting used for the logging embeds (and not on commands for some reason)