### PR TITLE
`pg`: removed indentation levels and added link to pg rules

### DIFF
--- a/commands/common/pg.js
+++ b/commands/common/pg.js
@@ -12,12 +12,15 @@ module.exports = {
         .setColor('#FF7100')
         .setAuthor({name: botIdent().activeBot.botName,iconURL: botIdent().activeBot.icon})
         .setThumbnail(botIdent().activeBot.icon)
-        .setDescription(`**How to join the Private Group**
-                            1. Open the Social Menu (Menu > Social)
-                            2. On the Friends tab, use the search box to find "${botIdent().activeBot.communityName}".
-                            3. Select the "${botIdent().activeBot.communityName}" and click "Request to join private group"
-                            4. The Request will be automatically approved
-                            5. Return to the menu, select Start > Private Group > ${botIdent().activeBot.communityName} > Join Group`)
+        .setDescription(
+            `**How to join the Private Group**\n` +
+            `1. Open the Social Menu (Menu > Social)\n` +
+            `2. On the Friends tab, use the search box to find "${botIdent().activeBot.communityName}".\n` +
+            `3. Select the "${botIdent().activeBot.communityName}" and click "Request to join private group"\n` +
+            `4. The Request will be automatically approved\n` +
+            `5. Return to the menu, select Start > Private Group > ${botIdent().activeBot.communityName} > Join Group\n` +
+            `\nPlease read the Private Group Rules before joining: <#1054193210324439082>`
+        )
         .setFooter({ text: `Joining ${botIdent().activeBot.communityName} Private Group`, iconURL: botIdent().activeBot.icon });
         interaction.reply({embeds: [returnEmbed]})
     }

--- a/commands/common/pg.js
+++ b/commands/common/pg.js
@@ -1,5 +1,6 @@
 const Discord = require("discord.js");
 const { botIdent } = require('../../functions');
+const config = require('../../config.json');
 module.exports = {
     data: new Discord.SlashCommandBuilder()
     .setName(`pg`)
@@ -7,6 +8,9 @@ module.exports = {
     // .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
     permissions:0,
     execute (interaction) {
+        const channels = interaction.guild.channels.cache;
+        const rulesChannelId = channels.find(channel => channel.name === config.Warden.channels.privateGroupRules).id;
+
         const returnEmbed = new Discord.EmbedBuilder()
         .setTitle(`${botIdent().activeBot.communityName} Private Group`)
         .setColor('#FF7100')
@@ -19,7 +23,7 @@ module.exports = {
             `3. Select the "${botIdent().activeBot.communityName}" and click "Request to join private group"\n` +
             `4. The Request will be automatically approved\n` +
             `5. Return to the menu, select Start > Private Group > ${botIdent().activeBot.communityName} > Join Group\n` +
-            `\nPlease read the Private Group Rules before joining: <#1054193210324439082>`
+            `\nPlease read the Private Group Rules before joining: <#${rulesChannelId}>`
         )
         .setFooter({ text: `Joining ${botIdent().activeBot.communityName} Private Group`, iconURL: botIdent().activeBot.icon });
         interaction.reply({embeds: [returnEmbed]})

--- a/commands/common/pg.js
+++ b/commands/common/pg.js
@@ -3,29 +3,31 @@ const { botIdent } = require('../../functions');
 const config = require('../../config.json');
 module.exports = {
     data: new Discord.SlashCommandBuilder()
-    .setName(`pg`)
-    .setDescription(`Posts info on how to join the ${botIdent().activeBot.communityName} Private Group`),
+        .setName(`pg`)
+        .setDescription(`Posts info on how to join the ${botIdent().activeBot.communityName} Private Group`),
     // .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
-    permissions:0,
-    execute (interaction) {
+    permissions: 0,
+    execute(interaction) {
         const channels = interaction.guild.channels.cache;
-        const rulesChannelId = channels.find(channel => channel.name === config.Warden.channels.privateGroupRules).id;
+        const rulesChannelId = channels.find(
+            channel => channel.name === config[botIdent().activeBot.botName].channels.privateGroupRules
+        ).id;
 
         const returnEmbed = new Discord.EmbedBuilder()
-        .setTitle(`${botIdent().activeBot.communityName} Private Group`)
-        .setColor('#FF7100')
-        .setAuthor({name: botIdent().activeBot.botName,iconURL: botIdent().activeBot.icon})
-        .setThumbnail(botIdent().activeBot.icon)
-        .setDescription(
-            `**How to join the Private Group**\n` +
-            `1. Open the Social Menu (Menu > Social)\n` +
-            `2. On the Friends tab, use the search box to find "${botIdent().activeBot.communityName}".\n` +
-            `3. Select the "${botIdent().activeBot.communityName}" and click "Request to join private group"\n` +
-            `4. The Request will be automatically approved\n` +
-            `5. Return to the menu, select Start > Private Group > ${botIdent().activeBot.communityName} > Join Group\n` +
-            `\nPlease read the Private Group Rules before joining: <#${rulesChannelId}>`
-        )
-        .setFooter({ text: `Joining ${botIdent().activeBot.communityName} Private Group`, iconURL: botIdent().activeBot.icon });
-        interaction.reply({embeds: [returnEmbed]})
+            .setTitle(`${botIdent().activeBot.communityName} Private Group`)
+            .setColor('#FF7100')
+            .setAuthor({ name: botIdent().activeBot.botName, iconURL: botIdent().activeBot.icon })
+            .setThumbnail(botIdent().activeBot.icon)
+            .setDescription(
+                `**How to join the Private Group**\n` +
+                `1. Open the Social Menu (Menu > Social)\n` +
+                `2. On the Friends tab, use the search box to find "${botIdent().activeBot.communityName}".\n` +
+                `3. Select the "${botIdent().activeBot.communityName}" and click "Request to join private group"\n` +
+                `4. The Request will be automatically approved\n` +
+                `5. Return to the menu, select Start > Private Group > ${botIdent().activeBot.communityName} > Join Group\n` +
+                `\nPlease read the Private Group Rules before joining: <#${rulesChannelId}>`
+            )
+            .setFooter({ text: `Joining ${botIdent().activeBot.communityName} Private Group`, iconURL: botIdent().activeBot.icon });
+        interaction.reply({ embeds: [returnEmbed] })
     }
 }

--- a/config.json
+++ b/config.json
@@ -92,6 +92,9 @@
                 "Ambassador"
             ]
         },
+        "channels": {
+            "privateGroupRules": "Private Group Rules"
+        },
         "testServer": {
             "otherRoles": [
                 { "name": "55555555555555", "roles": [555555555555555]},


### PR DESCRIPTION
looks like this now:
![image](https://github.com/user-attachments/assets/5f9dcbe4-9b90-40c6-92f2-335d098b73aa)

- Updated the `pg` command to dynamically reference the Private Group Rules channel by name from the config. This makes it easier to update channel references without hardcoding the channel ID.
- Removed the indentation