### PR TITLE
Update /engineering command

### DIFF
--- a/commands/Warden/ax-info/engineering.js
+++ b/commands/Warden/ax-info/engineering.js
@@ -12,12 +12,12 @@ module.exports = {
         .setAuthor({name: botIdent().activeBot.botName,iconURL: botIdent().activeBot.icon})
         .setThumbnail("https://edassets.org/static/img/engineers/Engineer_icon.png")
         .addFields(
-            {name: "ED Materials", value: "https://sites.google.com/view/elite-materials/home\nComprehensive guide on where and how to farm engineering materials. This is the single best resource for engineering." },
-            {name: "AX Engineer Unlock Guide", value: "https://wiki.antixenoinitiative.com/en/Unlocking-Engineers\nAXI's guide for unlocking engineers and how to engineer."},
+            {name: "AXI Engineer Unlock Guide", value: "https://wiki.antixenoinitiative.com/en/Unlocking-Engineers\nAXI's guide for unlocking engineers and how to engineer."},
             {name: "Engineering and Module Unlock Costs", value: "https://inara.cz/elite/techbroker/\nList of module unlock costs and engineering roll costs."},
-            {name: "AXI Odyssey Engineering", value: "https://wiki.antixenoinitiative.com/en/engineering-odyssey\nAXI's guide to odyssey engineering materials."},
-            {name: "AXI Horizons Engineering", value: "https://wiki.antixenoinitiative.com/en/engineering\nAXI's engineering material guide."},
+            {name: "AXI Ship Engineering Materials", value: "https://wiki.antixenoinitiative.com/en/engineering-materials\nAXI's ship engineering materials guide."},
+            {name: "AXI Spacesuit Engineering", value: "https://wiki.antixenoinitiative.com/en/engineering-odyssey\nAXI's guide to spacesuit engineering materials."},
             {name: "AXI Synthesis Calculator", value: "https://wiki.antixenoinitiative.com/en/synthesis\nInfo on AX synth costs."},
+            {name: "ED Materials", value: "https://sites.google.com/view/elite-materials/home\nComprehensive guide on where and how to farm engineering materials. This is the single best resource for engineering." },
         )
         interaction.reply({embeds: [returnEmbed.setTimestamp()]})
     }


### PR DESCRIPTION
This PR does the following:
- Changes the engineering materials link to the updated AXI Wiki link
- Moves ED Materials to the end of the list in favor of our own more up-to-date engineering materials guide
- Clarifies `Odyssey Engineering` to `Spacesuit Engineering` and `Horizons Engineering` to `Ship Engineering`